### PR TITLE
add getActionType; check for redux inspector plugin;

### DIFF
--- a/packages/flipperkit_redux_middleware/lib/flipperkit_redux_middleware.dart
+++ b/packages/flipperkit_redux_middleware/lib/flipperkit_redux_middleware.dart
@@ -10,17 +10,25 @@ class FlipperKitReduxMiddleware<State> implements MiddlewareClass<State> {
   FlipperReduxInspectorPlugin _flipperReduxInspectorPlugin;
 
   bool Function(String actionType) filter;
+  String Function(dynamic action) getActionType;
 
   FlipperKitReduxMiddleware({
     this.filter,
+    this.getActionType,
   });
 
   @override
   void call(Store<State> store, dynamic action, NextDispatcher next) {
-    String actionType = action.runtimeType.toString();
+    String actionType;
     dynamic prevState = json.encode(store.state);
     next(action);
-    
+
+    if (getActionType != null ) {
+      actionType = getActionType(action);
+    } else {
+      actionType = action.runtimeType.toString();
+    }
+
     if (filter != null && filter(actionType)) {
       return;
     }
@@ -38,7 +46,7 @@ class FlipperKitReduxMiddleware<State> implements MiddlewareClass<State> {
     try {
        payload = json.encode(action);
     } catch (e) {}
-    
+
     ActionInfo actionInfo = new ActionInfo(
       uniqueId: uniqueId,
       actionType: actionType,
@@ -48,6 +56,8 @@ class FlipperKitReduxMiddleware<State> implements MiddlewareClass<State> {
       nextState: nextState,
     );
 
-    _flipperReduxInspectorPlugin.report(actionInfo);
+    if (_flipperReduxInspectorPlugin != null ) {
+      _flipperReduxInspectorPlugin.report(actionInfo);
+    }
   }
 }


### PR DESCRIPTION
This PR includes two changes to the FlipperKitReduxMiddleware:

1) add `getActionType` to FlipperKitReduxMiddleware

I personally do not use `action.runtimeType.toString()` when identifying my actions. Instead, I have overwritten the action.toString() method to give a better descriptor.  This proposed addition would be to allow users to pick how they want the action to be labeled.

2) check if `_flipperReduxInspectorPlugin` is null before calling `.report`

I was getting an error when running my application's main function asynchronously. The `.report` method was getting called on a null value of `_flipperReduxInspectorPlugin`.  This proposed change would not call the report method if the value is null. 